### PR TITLE
Modified README and modified bick message fault construct to allow string or array

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The logic is the same as when publishing one message. The difference is that you
 #### Example
 ```php
 try {
-    $publisher = $bick->publisher();
+    $publisher = $bick->publisher(BickPublisher::class);
     
     //Set the persistence adapter
     $publisher->setPersistenceAdapter($adapter);

--- a/src/Message/BickMessageFault.php
+++ b/src/Message/BickMessageFault.php
@@ -20,10 +20,10 @@ final class BickMessageFault implements \JsonSerializable, BickMessageFaultInter
 
     /**
      * BickMessageFault constructor.
-     * @param string|array $message
+     * @param string|array|null $message
      * @param int $code
      */
-    public function __construct(?string $message, int $code)
+    public function __construct($message, int $code)
     {
         if (is_string($message) || is_array($message)) {
             $this->message = $message;

--- a/src/Message/BickMessageFaultInterface.php
+++ b/src/Message/BickMessageFaultInterface.php
@@ -14,10 +14,10 @@ interface BickMessageFaultInterface {
     /**
      * BickMessageFaultInterface constructor.
      *
-     * @param mixed|string $message
+     * @param string|array|null $message
      * @param int $code
      */
-    public function __construct(?string $message, int $code);
+    public function __construct($message, int $code);
 
     /**
      * @return array|mixed


### PR DESCRIPTION
- Added class name to `publisher` method in the README
- Modified `BickMessageFault` and `BickMessageFaultInterface` construct method to allow string or array (mixed)